### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-sh.yml
+++ b/.github/workflows/lint-sh.yml
@@ -2,6 +2,9 @@ name: Lint Shell Scripts
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: Shell Linting

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -2,6 +2,9 @@ name: Run AB Update Tool Tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   run_ab_update_tool_tests:
     name: Running AB Update Tool Tests


### PR DESCRIPTION
Potential fix for [https://github.com/open-edge-platform/edge-microvisor-update-tool/security/code-scanning/1](https://github.com/open-edge-platform/edge-microvisor-update-tool/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the operations performed in this workflow. This ensures that the workflow has the minimal permissions required and avoids granting unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
